### PR TITLE
SVY-11332 ability to disable formname fragmentt identifier in ng client url

### DIFF
--- a/servoy_ngclient/war/js/servoyWindowManager.ts
+++ b/servoy_ngclient/war/js/servoyWindowManager.ts
@@ -179,7 +179,7 @@ angular.module( 'servoyWindowManager', ['sabloApp'] )	// TODO Refactor so that w
 			};
 			return self;
 
-		}] ).factory( "$windowService", function( $servoyWindowManager: servoy.IServoyWindowManager, $log: sablo.ILogService, $rootScope: servoy.IRootScopeService, $solutionSettings: servoy.SolutionSettings, $window: angular.IWindowService, $timeout: angular.ITimeoutService, $formService, $sabloApplication: sablo.ISabloApplication, webStorage, WindowType: servoy.WindowType, $servoyInternal, $templateCache: angular.ITemplateCacheService, $location: angular.ILocationService, $sabloLoadingIndicator, $sabloTestability ) {
+		}] ).factory( "$windowService", function( $servoyWindowManager: servoy.IServoyWindowManager, $log: sablo.ILogService, $rootScope: servoy.IRootScopeService, $solutionSettings: servoy.SolutionSettings, $window: angular.IWindowService, $timeout: angular.ITimeoutService, $formService, $sabloApplication: sablo.ISabloApplication, webStorage, WindowType: servoy.WindowType, $servoyInternal, $templateCache: angular.ITemplateCacheService, $location: angular.ILocationService, $sabloLoadingIndicator, $sabloTestability, $svyUIProperties ) {
 			var instances = $servoyWindowManager.instances;
 			var formTemplateUrls: { [s: string]: string; } = {};
 			var storage = webStorage.local;
@@ -448,20 +448,13 @@ angular.module( 'servoyWindowManager', ['sabloApp'] )	// TODO Refactor so that w
 					if ( instances[name] && instances[name].type != WindowType.WINDOW ) {
 						instances[name].form = form;
 						instances[name].navigatorForm = navigatorForm;
-					}
-					else if ( $solutionSettings.windowName == name ) { // main window form switch
+					} else if ( $solutionSettings.windowName == name ) { // main window form switch
 						$solutionSettings.mainForm = form;
 						$solutionSettings.navigatorForm = navigatorForm;
-						var formanchor = '#' + form.name;
-						if ($location.url().indexOf('#') === -1 )
-						{
-							$location.url( $location.url() + formanchor );
-						}	
-						else
-						{
-							var url = $location.url().substring(0,$location.url().indexOf('#'));
-							$location.url( url +  formanchor);
-						}	
+
+						if ($svyUIProperties.getUIProperty("servoy.ngclient.formbased_browser_history") !== false ) {
+							$location.hash(form.name)
+			            }
 					}
 					if ( !$rootScope.$$phase ) {
 						if ( $log.debugLevel === $log.SPAM ) $log.debug( "svy * Will call digest from switchForm for root scope" );

--- a/servoy_shared/src/com/servoy/j2db/scripting/info/NGCONSTANTS.java
+++ b/servoy_shared/src/com/servoy/j2db/scripting/info/NGCONSTANTS.java
@@ -49,6 +49,19 @@ public class NGCONSTANTS implements IPrefixedConstantsObject
 	 */
 	public static final String WINDOW_TIMEOUT = "window.timeout"; //$NON-NLS-1$
 
+	/**
+	 * By default the NGClient appends the name of the current main form to the url in the address bar of the browser using a fragment identifier (#....)
+	 * <p>
+	 * By setting the FORM_BASED_BROWSER_HISTORY property to false, this is disabled
+	 *
+	 * The value can be true/false
+	 * DEFAULT: true
+	 *
+	 * @sample
+	 * application.putClientProperty(APP_NG_PROPERTY.FORM_BASED_BROWSER_HISTORY, false);
+	 */
+	public static final String FORM_BASED_BROWSER_HISTORY = "servoy.ngclient.formbased_browser_history"; //$NON-NLS-1$
+
 	public String getPrefix()
 	{
 		return "APP_NG_PROPERTY";


### PR DESCRIPTION
Implements the ability to disable the adding of the main controllers formname to the NGCLients URL as fragment identifier SVY-11332