### PR TITLE
SVY-12775 Ability to open external URL in main window/tab and close solution without creating a history entry in the browser

### DIFF
--- a/servoy_ngclient/war/js/servoy_app.ts
+++ b/servoy_ngclient/war/js/servoy_app.ts
@@ -1251,9 +1251,11 @@ angular.module('servoyApp', ['sabloApp', 'servoy','webStorageModule','servoy-com
 						$window.document.body.appendChild(ifrm);
 					}
 				}
-				else {
-					$window.open(url,target,targetOptions);
-				}
+				else  if (target === '_self' && targetOptions === 'no-history=true') {
+			        $window.location.replace(url)
+			    } else {
+			        $window.open(url,target,targetOptions);
+			    }
 			}, timeout*1000)
 		},
 		setStatusText:function(text){


### PR DESCRIPTION
Implements a way to a showUrl in the NGClient that doesn't create an entry in the browser history

Done by using $window.location.replace instead of $window.open in the browser for application.showUrl if the target === '_self' and the targetOptions === 'no-history=true'