### PR TITLE
SVY-12815 complete i18n customization support

### DIFF
--- a/servoy_shared/src/com/servoy/j2db/dataprocessing/FoundSetManager.java
+++ b/servoy_shared/src/com/servoy/j2db/dataprocessing/FoundSetManager.java
@@ -1956,6 +1956,10 @@ public class FoundSetManager implements IFoundSetManagerInternal
 		{
 			return new SortColumn(c, relations.size() == 0 ? null : relations.toArray(new Relation[relations.size()]));
 		}
+
+		if (logIfCannotBeResolved)
+			Debug.log("Non-existing column " + dataProviderID + " specified in sort, excluding it from the sort", new Exception(dataProviderID));
+
 		return null;
 	}
 

--- a/servoy_shared/src/com/servoy/j2db/persistence/Column.java
+++ b/servoy_shared/src/com/servoy/j2db/persistence/Column.java
@@ -663,7 +663,23 @@ public class Column extends BaseColumn implements Serializable, IColumn, ISuppor
 				default :
 					if (ci.hasFlag(IBaseColumn.TENANT_COLUMN))
 					{
-						return application.getTenantValue();
+						Object tenantValue = application.getTenantValue();
+
+						if (tenantValue != null && tenantValue.getClass().isArray())
+						{
+							Object[] tenantValues = (Object[])tenantValue;
+							tenantValue = null;
+
+							for (Object value : tenantValues)
+							{
+								if (value != null)
+								{
+									return value;
+								}
+							}
+						}
+
+						return tenantValue;
 					}
 					return null;
 			}

--- a/servoy_shared/src/com/servoy/j2db/scripting/JSI18N.java
+++ b/servoy_shared/src/com/servoy/j2db/scripting/JSI18N.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.Locale;
+import java.util.Locale.Builder;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
@@ -80,13 +81,60 @@ public class JSI18N implements IJSI18N
 	 * i18n.setLocale('en','US');
 	 *
 	 * @param language The lowercase 2 letter code
-	 *
-	 * @param country The upper case 2 letter code.
+	 * @param country The upper case 2 letter code
 	 */
 	@JSFunction
 	public void setLocale(String language, String country)
 	{
 		application.setLocale(new Locale(language, country));
+	}
+
+	/**
+	 * Set/Overwrite the locale for this client.
+	 * All forms not yet loaded will change (execute this in solution startup or first form).
+	 *
+	 * The language must be a lowercase 2 letter code defined by ISO-639.
+	 * see ISO 639-1 codes at http://en.wikipedia.org/wiki/List_of_ISO_639-1_code
+	 *
+	 * The country must be an upper case 2 letter code defined by ISO-3166
+	 * see ISO-3166-1 codes at http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+	 *
+	 * The extensions must be an array of strings indicating for example different industries. Each extension string must consist of only letters and digits with a max length of 8 characters
+	 * see private extensions at https://docs.oracle.com/javase/tutorial/i18n/locale/extensions.html
+	 *
+	 * NOTE: For more information on i18n, see the chapter on Internationalization in the Servoy Developer User's Guide, and the chapter on Internationalization-I18N in the Programming Guide.
+	 *
+	 * @sample
+	 * //Warning: already created form elements with i18n text lookup will not change,
+	 * //so call this method in the solution startup method or in methods from first form
+	 *
+	 * i18n.setLocale('en','US');
+	 * @param language The lowercase 2 letter code
+	 * @param country The upper case 2 letter code
+	 * @param extensions array of extensions strings
+	 */
+	@JSFunction
+	public void setLocale(String language, String country, String[] extensions)
+	{
+		Builder b = new Locale.Builder();
+		String extensionTags = ""; //$NON-NLS-1$
+
+		b.setLanguage(language).setRegion(country);
+
+		for (String extension : extensions)
+		{
+			if (extension.matches("[a-zA-Z0-9]{1,8}")) //$NON-NLS-1$
+			{
+				extensionTags = (extensionTags.length() > 0 ? "-" : "") + extension; //$NON-NLS-1$ //$NON-NLS-2$
+			}
+		}
+
+		if (extensionTags.length() > 0)
+		{
+			b.setExtension(Locale.PRIVATE_USE_EXTENSION, extensionTags);
+		}
+
+		application.setLocale(b.build());
 	}
 
 	/**
@@ -118,6 +166,22 @@ public class JSI18N implements IJSI18N
 	public String getCurrentCountry()
 	{
 		return application.getLocale().getCountry();
+	}
+
+	/**
+	 * Gets the current extensions; based on the current locale settings in the Servoy Client Locale preferences.
+	 *
+	 * NOTE: For more information on i18n, see the chapter on Internationalization in the Servoy Developer User's Guide, and the chapter on Internationalization-I18N in the Programming Guide.
+	 *
+	 * @sample
+	 * var currExtensions = i18n.getCurrentExtensions();
+	 *
+	 * @return an array of Strings representing the current extensions.
+	 */
+	@JSFunction
+	public String[] getCurrentExtensions()
+	{
+		return application.getLocale().getExtension(Locale.PRIVATE_USE_EXTENSION).split("-"); //$NON-NLS-1$
 	}
 
 	/**

--- a/servoy_shared/src/com/servoy/j2db/scripting/JSSecurity.java
+++ b/servoy_shared/src/com/servoy/j2db/scripting/JSSecurity.java
@@ -209,8 +209,9 @@ public class JSSecurity implements IReturnedTypesProvider, IConstantsObject, IJS
 							{
 								try
 								{
+									int operator = value.getClass().isArray() ? IBaseSQLCondition.IN_OPERATOR : IBaseSQLCondition.EQUALS_OPERATOR;
 									application.getFoundSetManager().addTableFilterParam("_svy_tenant_id_table_filter", server.getName(), table,
-										new DataproviderTableFilterdefinition(column.getDataProviderID(), IBaseSQLCondition.EQUALS_OPERATOR, value));
+										new DataproviderTableFilterdefinition(column.getDataProviderID(), operator, value));
 								}
 								catch (ServoyException e)
 								{

--- a/servoy_shared/src/com/servoy/j2db/scripting/JSSecurity.java
+++ b/servoy_shared/src/com/servoy/j2db/scripting/JSSecurity.java
@@ -159,16 +159,18 @@ public class JSSecurity implements IReturnedTypesProvider, IConstantsObject, IJS
 	}
 
 	/**
-	 * Set the tenant value for this Client, this value will be used as the value for all tables that have a column marked as a tenant column.
-	 * This results in adding a table filter for that table based on that column and the this value.
+	 * Set the tenant value or values for this Client
+	 *
+	 * The value(s) will be used by tableFilters added to any table that has a column flagged as a Tenant column.
 	 *<p>
-	 * This value will be auto filled in for all the columns that are marked as a tenant column.
+	 * The value will also be used as auto-enter value for new records for the columns marked as Tenant column.
+	 * When multiple tenant values are provided, the first non-null value will be used as auto-enter value for new records
 	 *</p>
 	 *<p>
-	 *  When this is set to a value then all databroadcast from other clients will only be recieved by this client when other clients also have
-	 *  this tenant value set or from clients with no tenant value set. So be sure that you don't access or depend on data from tenant based tables which are outside of this tenant value.
+	 *  When a tenant value is set the client will only receive databroadcasts from other clients that have no or the same tenant value(s) set
+	 *  Be sure to not access or depend on records having different tenant values, as no databroadcasts will be received for those
 	 *</p>
-	 * @param value the tenant value used for all tenant columns.
+	 * @param value a single tenant value or an array of tenant values to filter tables having a column flagged as Tenant column by.
 	 */
 	@JSFunction
 	public void setTenantValue(Object value)


### PR DESCRIPTION
- Adds i18n.setLocale(language, country, extensions)
- Adds i18.getcurrentExtensions()
- Limits reading from the i18n messages table in Developer and during deployment to records where columns flagged a Tenant column have a null value
- Limits updating/deleting records in the i18n messages table in Developer and during deployment to records where columns flagged a Tenant column have a null value

NOTE: these changes assume that the Application Server uses com.servoy.j2db.persistance.I18NUtil.java for reading/writing the i18n tables as well
NOTE 2: this PR includes the changes also provided in the separate (open) PR https://github.com/Servoy/servoy-client/pull/9 as they are required to satisfy both use-cases described in SVY-12815 completely
NOTE 3: this PR does NOT include modifications to the i18N dialogs that Servoy ships with, as I do not think they are a must-have (see SVY-12815 for more info)

