### PR TITLE
fix SVY-15604 implement instanceof support for RecordingScriptable

### DIFF
--- a/servoy_shared/src/com/servoy/j2db/scripting/InstanceOfScope.java
+++ b/servoy_shared/src/com/servoy/j2db/scripting/InstanceOfScope.java
@@ -49,6 +49,18 @@ public class InstanceOfScope implements Scriptable
 		else if (instance instanceof RecordingScriptable)
 		{
 			Object unwrap = ((RecordingScriptable)instance).unwrap();
+
+			if (unwrap instanceof Scriptable)
+			{
+				Scriptable proto = ((Scriptable)unwrap).getPrototype();
+
+				while (proto != null)
+				{
+					if (cls.isInstance(proto)) return true;
+					proto = proto.getPrototype();
+				}
+			}
+
 			return cls.isInstance(unwrap);
 		}
 		else if (instance instanceof IInstanceOf)


### PR DESCRIPTION
based on the prototype chain of the wrapped scriptable

Needed to make `this instanceof JSRecord` work for the `this` value
inside calculations