### PR TITLE
SVY-14678 first iteration of statement batching

### DIFF
--- a/servoy_shared/src/com/servoy/j2db/dataprocessing/EditRecordList.java
+++ b/servoy_shared/src/com/servoy/j2db/dataprocessing/EditRecordList.java
@@ -23,9 +23,11 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.locks.ReentrantLock;
@@ -553,6 +555,7 @@ public class EditRecordList
 				}
 
 				Map<IRecordInternal, Integer> processed = new HashMap<IRecordInternal, Integer>();
+				RowUpdateInfo previousRowInfo = null;
 				for (IRecordInternal tmp = getFirstElement(editedRecords, recordsToSave); tmp != null; tmp = getFirstElement(editedRecords, recordsToSave))
 				{
 					// check if we do not have an infinite recursive loop
@@ -626,11 +629,14 @@ public class EditRecordList
 							}
 							if (!validationErrors)
 							{
-								RowUpdateInfo rowUpdateInfo = getRecordUpdateInfo(record);
+								RowUpdateInfo rowUpdateInfo = getRecordUpdateInfo(record, previousRowInfo);
+
 								if (rowUpdateInfo != null)
 								{
 									rowUpdateInfo.setRecord(record);
 									rowUpdates.add(rowUpdateInfo);
+
+									previousRowInfo = rowUpdateInfo;
 								}
 								else
 								{
@@ -773,11 +779,13 @@ public class EditRecordList
 				}
 			}
 
-			ISQLStatement[] statements = new ISQLStatement[infos.length];
-			for (int i = 0; i < infos.length; i++)
+			// Extracting unique statements from all info's: multiple info's can share the same statement of the records are batched together on the statement level
+			Set<ISQLStatement> uniqueStatements = new LinkedHashSet<ISQLStatement>(infos.length);
+			for (RowUpdateInfo element : infos)
 			{
-				statements[i] = infos[i].getISQLStatement();
+				uniqueStatements.add(element.getISQLStatement());
 			}
+			ISQLStatement[] statements = uniqueStatements.toArray(new ISQLStatement[uniqueStatements.size()]);
 
 			// TODO if one statement fails in a transaction how do we know which one? and should we rollback all rows in these statements?
 			Object[] idents = null;
@@ -1137,7 +1145,7 @@ public class EditRecordList
 	/*
 	 * _____________________________________________________________ Methods for data manipulation
 	 */
-	private RowUpdateInfo getRecordUpdateInfo(IRecordInternal state) throws ServoyException
+	private RowUpdateInfo getRecordUpdateInfo(IRecordInternal state, RowUpdateInfo previous) throws ServoyException
 	{
 		Table table = state.getParentFoundSet().getSQLSheet().getTable();
 		RowManager rowManager = fsm.getRowManager(fsm.getDataSource(table));
@@ -1155,7 +1163,7 @@ public class EditRecordList
 			gt.addRecord(table.getServerName(), state);
 		}
 
-		RowUpdateInfo rowUpdateInfo = rowManager.getRowUpdateInfo(rowData, hasAccess(table, IRepository.TRACKING));
+		RowUpdateInfo rowUpdateInfo = rowManager.getRowUpdateInfo(rowData, hasAccess(table, IRepository.TRACKING), previous);
 		return rowUpdateInfo;
 	}
 

--- a/servoy_shared/src/com/servoy/j2db/dataprocessing/EditRecordList.java
+++ b/servoy_shared/src/com/servoy/j2db/dataprocessing/EditRecordList.java
@@ -86,12 +86,9 @@ public class EditRecordList
 	private final Map<IRecordInternal, List<IPrepareForSave>> recordTested = Collections.synchronizedMap(new HashMap<IRecordInternal, List<IPrepareForSave>>()); //tested for form.OnRecordEditStop event
 	private boolean preparingForSave;
 
-	private final boolean disableInsertsReorder;
-
 	public EditRecordList(FoundSetManager fsm)
 	{
 		this.fsm = fsm;
-		disableInsertsReorder = Utils.getAsBoolean(fsm.getApplication().getSettings().getProperty("servoy.disable.record.insert.reorder", "false")); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
 	public IRecordInternal[] getFailedRecords()
@@ -712,7 +709,7 @@ public class EditRecordList
 			}
 
 			RowUpdateInfo[] infos = rowUpdates.toArray(new RowUpdateInfo[rowUpdates.size()]);
-			if (infos.length > 1 && !disableInsertsReorder)
+			if (infos.length > 1 && !fsm.disableInsertsReorder)
 			{
 				// search if there are new row pks used that are
 				// used in records before this record and sort it based on that.

--- a/servoy_shared/src/com/servoy/j2db/dataprocessing/FoundSetManager.java
+++ b/servoy_shared/src/com/servoy/j2db/dataprocessing/FoundSetManager.java
@@ -188,7 +188,7 @@ public class FoundSetManager implements IFoundSetManagerInternal
 		chunkSize = Utils.getAsInteger(app.getSettings().getProperty("servoy.foundset.chunkSize", Integer.toString(30)));//records to be get in one roundtrip //$NON-NLS-1$
 		initialRelatedChunkSize = Utils.getAsInteger(app.getSettings().getProperty("servoy.foundset.initialRelatedChunkSize", Integer.toString(chunkSize * 2))); //initial related records to get in one roundtrip//$NON-NLS-1$
 		loadRelatedRecordsIfParentIsNew = Utils.getAsBoolean(app.getSettings().getProperty("servoy.foundset.loadRelatedRecordsIfParentIsNew", "false")); //force-load of possible existing records in DB when initializing a related foundset when the parent is new and the relations is restricted on the rowIdentifier columns of the parent record //$NON-NLS-1$ //$NON-NLS-2$
-		statementBatching = Utils.getAsBoolean(app.getSettings().getProperty("servoy.statementBatching", "false")); // whether to batch inserts/updates for rows together in the same SQLStatement where possible
+		statementBatching = Utils.getAsBoolean(app.getSettings().getProperty("servoy.foundset.statementBatching", "false")); // whether to batch inserts/updates for rows together in the same SQLStatement where possible //$NON-NLS-1$ //$NON-NLS-2$
 		disableInsertsReorder = statementBatching || Utils.getAsBoolean(app.getSettings().getProperty("servoy.disable.record.insert.reorder", "false")); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 

--- a/servoy_shared/src/com/servoy/j2db/dataprocessing/FoundSetManager.java
+++ b/servoy_shared/src/com/servoy/j2db/dataprocessing/FoundSetManager.java
@@ -167,6 +167,7 @@ public class FoundSetManager implements IFoundSetManagerInternal
 	public final int chunkSize;
 	public final int initialRelatedChunkSize;
 	public final boolean loadRelatedRecordsIfParentIsNew;
+	public final boolean statementBatching;
 
 	private final List<Runnable> fireRunabbles = new ArrayList<Runnable>();
 
@@ -186,6 +187,7 @@ public class FoundSetManager implements IFoundSetManagerInternal
 		chunkSize = Utils.getAsInteger(app.getSettings().getProperty("servoy.foundset.chunkSize", Integer.toString(30)));//records to be get in one roundtrip //$NON-NLS-1$
 		initialRelatedChunkSize = Utils.getAsInteger(app.getSettings().getProperty("servoy.foundset.initialRelatedChunkSize", Integer.toString(chunkSize * 2))); //initial related records to get in one roundtrip//$NON-NLS-1$
 		loadRelatedRecordsIfParentIsNew = Utils.getAsBoolean(app.getSettings().getProperty("servoy.foundset.loadRelatedRecordsIfParentIsNew", "false")); //force-load of possible existing records in DB when initializing a related foundset when the parent is new and the relations is restricted on the rowIdentifier columns of the parent record //$NON-NLS-1$ //$NON-NLS-2$
+		statementBatching = Utils.getAsBoolean(app.getSettings().getProperty("servoy.statementBatching", "false")); // whether to batch inserts/updates for rows together in the same SQLStatement where possible
 	}
 
 	/**

--- a/servoy_shared/src/com/servoy/j2db/dataprocessing/FoundSetManager.java
+++ b/servoy_shared/src/com/servoy/j2db/dataprocessing/FoundSetManager.java
@@ -168,6 +168,7 @@ public class FoundSetManager implements IFoundSetManagerInternal
 	public final int initialRelatedChunkSize;
 	public final boolean loadRelatedRecordsIfParentIsNew;
 	public final boolean statementBatching;
+	public final boolean disableInsertsReorder;
 
 	private final List<Runnable> fireRunabbles = new ArrayList<Runnable>();
 
@@ -188,6 +189,7 @@ public class FoundSetManager implements IFoundSetManagerInternal
 		initialRelatedChunkSize = Utils.getAsInteger(app.getSettings().getProperty("servoy.foundset.initialRelatedChunkSize", Integer.toString(chunkSize * 2))); //initial related records to get in one roundtrip//$NON-NLS-1$
 		loadRelatedRecordsIfParentIsNew = Utils.getAsBoolean(app.getSettings().getProperty("servoy.foundset.loadRelatedRecordsIfParentIsNew", "false")); //force-load of possible existing records in DB when initializing a related foundset when the parent is new and the relations is restricted on the rowIdentifier columns of the parent record //$NON-NLS-1$ //$NON-NLS-2$
 		statementBatching = Utils.getAsBoolean(app.getSettings().getProperty("servoy.statementBatching", "false")); // whether to batch inserts/updates for rows together in the same SQLStatement where possible
+		disableInsertsReorder = statementBatching || Utils.getAsBoolean(app.getSettings().getProperty("servoy.disable.record.insert.reorder", "false")); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
 	/**

--- a/servoy_shared/src/com/servoy/j2db/dataprocessing/RowManager.java
+++ b/servoy_shared/src/com/servoy/j2db/dataprocessing/RowManager.java
@@ -867,7 +867,12 @@ public class RowManager implements IModificationListener, IFoundSetEventListener
 					}
 				}
 
-				sqlUpdate = statement == null || !queryColumnsToRemove.isEmpty() ? (ISQLUpdate)AbstractBaseQuery.deepClone(sqlDesc.getSQLQuery())
+				if (!queryColumnsToRemove.isEmpty())
+				{
+					statement = null;
+				}
+
+				sqlUpdate = statement == null ? (ISQLUpdate)AbstractBaseQuery.deepClone(sqlDesc.getSQLQuery())
 					: statement.getUpdate();
 
 				for (Column c : queryColumnsToRemove)

--- a/servoy_shared/src/com/servoy/j2db/dataprocessing/RowManager.java
+++ b/servoy_shared/src/com/servoy/j2db/dataprocessing/RowManager.java
@@ -793,7 +793,7 @@ public class RowManager implements IModificationListener, IFoundSetEventListener
 				{
 					Row previousRow = previous.getRow();
 
-					if (previousRow.getRowManager() == this)
+					if (previousRow.getRowManager() == this && previousRow.existInDB() == doesExistInDB)
 					{
 						statement = (SQLStatement)previous.getISQLStatement();
 


### PR DESCRIPTION
Introduced 'servoy.statementBatching' property (default false) that will
batch statements for records on the same table together if:
- they are insert statements (so for newly created records)
- they the records are sibblings in the EditedRecord list
- don't use columns with Database Managed Auto-enter values
- don't use columns with a database Default value
- don't use tracking
- aren't for an Oracle database

All restrictions can be lifted by more code changes, without changing behavior, except for 2: an optional setting could be provided to aggressively reorder edited records to get the most optimized batching, but this might cause issues in implementations due to database-level constraints

This change DOES cause a behavior change IF the `servoy.batching` setting is set to true (which it is by default). Because the statements are batched and the execution of the batched statement happens as a single batch towards the database, if any exception occurs on the database with one of the inserts, all records in the batch is fail, all with the same exception