### PR TITLE
Remove  addFoundsetFilterParams/loadRecords/clear restrictions on global related foundsets

### DIFF
--- a/servoy_shared/src/com/servoy/j2db/dataprocessing/FoundSet.java
+++ b/servoy_shared/src/com/servoy/j2db/dataprocessing/FoundSet.java
@@ -16,7 +16,6 @@
  */
 package com.servoy.j2db.dataprocessing;
 
-
 import static com.servoy.j2db.dataprocessing.SQLGenerator.isDistinctAllowed;
 import static com.servoy.j2db.util.Utils.iterate;
 
@@ -1240,9 +1239,12 @@ public abstract class FoundSet implements IFoundSetInternal, IRowListener, Scrip
 			throw new IllegalStateException("couldn't load dataset on a foundset that has no table: " + this); //$NON-NLS-1$
 		}
 
-		if (!allowRelated && relationName != null) // on related foundset, only allow loadRecords without arguments
+		if (!allowRelated && relationName != null) // on non-global related foundset, only allow loadRecords without arguments
 		{
-			throw new IllegalStateException("Can't load data/records in a related foundset: " + this); //$NON-NLS-1$
+			if (this instanceof RelatedFoundSet && !((RelatedFoundSet)this).isGlobal())
+			{
+				throw new IllegalStateException("Can't load data/records in a related foundset: " + this); //$NON-NLS-1$
+			}
 		}
 
 		if (isInFindMode() && allowInFind)


### PR DESCRIPTION
Remove the restrictions that RelationFoundSet has when it comes to addFoundsetFilterParams/loadRecords/clear if the RelationFoundset instance is for a global relation

Premise of this change is that this allows a global related foundset to
be used as a drop in replacement for a regular, non-related FoundSet,
but have the benefit of automatically getting new records created
outside of the FS (other foundsets, databrodcasting) added to it, a
feature that is not available for non-global related foundsets