### PR TITLE
set parentContainer before onLoad is executes when using servoyApi.showForm

### DIFF
--- a/servoy_ngclient/src/com/servoy/j2db/server/ngclient/INGFormManager.java
+++ b/servoy_ngclient/src/com/servoy/j2db/server/ngclient/INGFormManager.java
@@ -30,6 +30,10 @@ public interface INGFormManager extends IBasicFormManager
 
 	IWebFormController getForm(String name);
 
+	IWebFormController getForm(String name, WebFormComponent parent);
+
+	IWebFormController leaseFormPanel(String name, WebFormComponent parent);
+
 	IWebFormController getCachedFormController(String formName);
 
 	IWebFormController getCurrentForm();

--- a/servoy_ngclient/src/com/servoy/j2db/server/ngclient/NGFormManager.java
+++ b/servoy_ngclient/src/com/servoy/j2db/server/ngclient/NGFormManager.java
@@ -283,10 +283,16 @@ public class NGFormManager extends BasicFormManager implements INGFormManager
 	@Override
 	public IWebFormController getForm(String name)
 	{
+		return getForm(name, null);
+	}
+
+	@Override
+	public IWebFormController getForm(String name, WebFormComponent parent)
+	{
 		IWebFormController fc = createdFormControllers.get(name);
 		if (fc == null)
 		{
-			fc = leaseFormPanel(name);
+			fc = leaseFormPanel(name, parent);
 		}
 		return fc;
 	}
@@ -300,6 +306,12 @@ public class NGFormManager extends BasicFormManager implements INGFormManager
 
 	@Override
 	public IWebFormController leaseFormPanel(String formName)
+	{
+		return leaseFormPanel(formName, null);
+	}
+
+	@Override
+	public IWebFormController leaseFormPanel(String formName, WebFormComponent parent)
 	{
 		if (formName == null) return null;
 
@@ -321,6 +333,10 @@ public class NGFormManager extends BasicFormManager implements INGFormManager
 				fp.init();
 				updateLeaseHistory(fp);
 				fp.setView(fp.getView());
+				if (parent != null)
+				{
+					fp.getFormUI().setParentContainer(parent);
+				}
 				fp.executeOnLoadMethod();
 			}
 			finally

--- a/servoy_ngclient/src/com/servoy/j2db/server/ngclient/scripting/ServoyApiObject.java
+++ b/servoy_ngclient/src/com/servoy/j2db/server/ngclient/scripting/ServoyApiObject.java
@@ -197,7 +197,7 @@ public class ServoyApiObject
 				formName = form.getName();
 			}
 		}
-		IWebFormController formController = app.getFormManager().getForm(formName);
+		IWebFormController formController = app.getFormManager().getForm(formName, this.component);
 		IWebFormController parentFormController = null;
 		if (this.component != null)
 		{


### PR DESCRIPTION
This PR eagerly sets the parent container of a IWebFormUI when a servoyApi.showForm(...) is called, so that controller.getFormContext() within the forms' onLoad method already knows about its context within the UI

Rationale: within the onLoad of a form the controller.getFormContext() doesn't return the context, even if the form is getting loaded because it's displayed within a container component that is being made visible and thus the context is technically/logically known.

This PR fixes that by passing on the component instance in which the form will be shown along when calling FormManager.getForm(...) and FormManager.leaseFormPanel, so leaseFormPanel can call `FormController.getFormUI().setParentContainer()` before calling `FormController.executeOnLoadMethod()`

This new behavior is tied to the new servoyApi.showForm, thus wont change existing behavior.

Prior to this change the equivalent of FormController.getFormUI().setParentContainer() would (conditionally) get called (via `component.updateVisibleForm(formController.getFormUI(), true, 0)`) if:
- [formController.notifyVisible returned true](https://github.com/p-bakker/servoy-client/blob/master/servoy_ngclient/src/com/servoy/j2db/server/ngclient/scripting/ServoyApiObject.java#L209)
- the [parentFormController is not null](https://github.com/p-bakker/servoy-client/blob/master/servoy_ngclient/src/com/servoy/j2db/server/ngclient/scripting/ServoyApiObject.java#L212)
- [component is not null](https://github.com/p-bakker/servoy-client/blob/master/servoy_ngclient/src/com/servoy/j2db/server/ngclient/scripting/ServoyApiObject.java#L246)

The first condition never returns false, so is always met. 
The second condition is I think also always met, because how can you have a servoyApi instance without a component and a component without a (parent)form?
The 3rd condition (while I think iis always met) is still being checked in leaseFormPanel

The usecase of this PR is twofold:
- being able to know the context in which a form is being shown in the onLoad method allows initialization code in the onLoad method to be context-aware, which at least in our solution solved a bunch of challenges
- being able to detect forms being accessed through code, triggering the form to be loaded (in which case controller.getFormContext() is not as expected), while the form is meant to just be shown through the UI, allows us to log warnings and thus get notified of potential coding issues     