### PR TITLE
Don't extend SafeArrayList if the object is null

### DIFF
--- a/servoy_shared/src/com/servoy/j2db/util/SafeArrayList.java
+++ b/servoy_shared/src/com/servoy/j2db/util/SafeArrayList.java
@@ -116,6 +116,11 @@ public class SafeArrayList<E> implements Collection<E>, List<E>, RandomAccess, C
 
 		if (index > s)
 		{
+			if (obj == null)
+			{
+				return null;
+			}
+			
 			for (int fill = s; fill <= index; fill++)
 			{
 				list.add(null);


### PR DESCRIPTION
Extending the list when the object is null takes up memory unnecessarily.