### PR TITLE
Potential fix for code scanning alert no. 83: Cross-site scripting

### DIFF
--- a/servoy_ngclient/src/com/servoy/j2db/server/ngclient/auth/CloudStatelessAccessManager.java
+++ b/servoy_ngclient/src/com/servoy/j2db/server/ngclient/auth/CloudStatelessAccessManager.java
@@ -147,7 +147,7 @@ public class CloudStatelessAccessManager extends AbstractAuthenticatorManager im
 	{
 		if (customHTML != null && customHTML.startsWith("<"))
 		{
-			return customHTML; // CodeQL[java/xss] - customHTML originates from the trusted Servoy Cloud backend response, not user input
+			return StringEscapeUtils.escapeHtml4(customHTML);
 		}
 		String loginHtml = getCloudLoginPage(request);
 		if (loginHtml != null) return loginHtml;


### PR DESCRIPTION
Potential fix for [https://github.com/Servoy/servoy-client/security/code-scanning/83](https://github.com/Servoy/servoy-client/security/code-scanning/83)

General fix: never render request-derived data as raw HTML unless it is cryptographically/verifiably trusted and transformed safely. For this code path, the safest no-functional-break approach is to stop treating `customHTML` as HTML markup in `CloudStatelessAccessManager` and instead HTML-escape it before embedding/rendering.

Best single fix in shown code: update `CloudStatelessAccessManager.getLoginHTML(...)` so that when `customHTML` is present, it is escaped with `StringEscapeUtils.escapeHtml4(customHTML)` and returned as text (or ignored as override). Since this method is the branch that currently allows raw HTML passthrough, this blocks the tainted flow before it reaches `writeSecuredHtmlResponse(...)`. `StringEscapeUtils` is already imported in that file, so no new dependency/import is needed.

Change location:
- `servoy_ngclient/src/com/servoy/j2db/server/ngclient/auth/CloudStatelessAccessManager.java`
- Method: `protected String getLoginHTML(HttpServletRequest request, String customHTML)`


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
