### PR TITLE
Potential fix for code scanning alert no. 71: Cross-site scripting

### DIFF
--- a/servoy_ngclient/src/com/servoy/j2db/server/ngclient/auth/CloudStatelessAccessManager.java
+++ b/servoy_ngclient/src/com/servoy/j2db/server/ngclient/auth/CloudStatelessAccessManager.java
@@ -575,7 +575,11 @@ public class CloudStatelessAccessManager extends AbstractAuthenticatorManager im
 				html = html.replace("<script ", "<script nonce='" + contentSecurityPolicyNonce + '\'');
 				html = html.replace("<style", "<style nonce='" + contentSecurityPolicyNonce + '\'');
 			}
-			if (initialURL != null) html = html.replace("</form>", "<input type='hidden' name='" + SVY_REDIRECT + "' value='" + initialURL + "'></form>");
+			if (initialURL != null)
+			{
+				String encodedInitialURL = Encode.forHtmlAttribute(initialURL);
+				html = html.replace("</form>", "<input type='hidden' name='" + SVY_REDIRECT + "' value='" + encodedInitialURL + "'></form>");
+			}
 			HTMLWriter.writeHTML(request, response, html);
 		}
 		else


### PR DESCRIPTION
Potential fix for [https://github.com/Servoy/servoy-client/security/code-scanning/71](https://github.com/Servoy/servoy-client/security/code-scanning/71)

Use **contextual output encoding at the point of HTML construction** in `CloudStatelessAccessManager.writeHTML(...)`.

Best fix (minimal functional impact):
- In `servoy_ngclient/src/com/servoy/j2db/server/ngclient/auth/CloudStatelessAccessManager.java`, update the line that injects `initialURL` into the hidden input’s `value` attribute.
- Encode `initialURL` with OWASP Java Encoder for HTML attribute context: `Encode.forHtmlAttribute(initialURL)`.
- Keep existing behavior (still includes the same redirect value semantically), but render it safely so special characters cannot break out of the attribute.

No new dependency is required because `org.owasp.encoder.Encode` is already imported in this file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
